### PR TITLE
Removed command string constants.

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -45,8 +45,10 @@ This style guide is inspired by the [Google style guide][gStyleGuide].
   data members are withou trailing underscore
 * **constant** names – leading k + CamelCase – this applies especially for
   static storage duration
-* **function** names – mixedCase (CamelCase with leading lowercase), capitalize
-  acronyms
+* **function** names:
+  * class methods - mixedCase (CamelCase with leading lowercase) it also
+    applies for acronyms
+  * other functions - all lower case as variables.
 * **getters** and **setters** – as variables
 * **namespace** names – all lowercase with underscores between words
 * **macro** names – capitals with underscores between names MY_MACRO

--- a/src/sprelay/core/k8090.cpp
+++ b/src/sprelay/core/k8090.cpp
@@ -31,17 +31,151 @@
 #include <QSerialPortInfo>
 #include <QStringBuilder>
 
-
 /*!
     \namespace K8090Traits
-    \brief Contains K8090 traits
+    \brief Contains traits for K8090 class.
 */
 using namespace K8090Traits;  // NOLINT(build/namespaces)
+
+/*!
+    \enum Command
+    \brief Scoped enumeration listing all commands.
+
+    See the Velleman %K8090 card manual.
+*/
+/*!
+    \var Command::RELAY_ON
+    \brief Switch realy on command.
+*/
+/*!
+    \var Command::RELAY_OFF
+    \brief Switch realy off command.
+*/
+/*!
+    \var Command::TOGGLE_RELAY
+    \brief Toggle realy command.
+*/
+/*!
+    \var Command::QUERY_RELAY
+    \brief Query relay status command.
+*/
+/*!
+    \var Command::SET_BUTTON_MODE
+    \brief Set button mode command.
+*/
+/*!
+    \var Command::BUTTON_MODE
+    \brief Query button mode command.
+*/
+/*!
+    \var Command::START_TIMER
+    \brief Start relay timer command.
+*/
+/*!
+    \var Command::SET_TIMER
+    \brief Set relay timer delay command.
+*/
+/*!
+    \var Command::TIMER
+    \brief Query timer delay command.
+*/
+/*!
+    \var Command::BUTTON_STATUS
+    \brief Button status command.
+*/
+/*!
+    \var Command::RELAY_STATUS
+    \brief Relay status command.
+*/
+/*!
+    \var Command::RESET_FACTORY_DEFAULTS
+    \brief Reset factory defaults command.
+*/
+/*!
+    \var Command::JUMPER_STATUS
+    \brief Jumper status command.
+*/
+/*!
+    \var Command::FIRMWARE_VERSION
+    \brief Firmware version command.
+*/
+/*!
+    \var Command::NONE
+    \brief The number of all commands represents also none command.
+*/
+
+/*!
+    \enum RelayID
+    \brief Scoped enumeration listing all 8 relays.
+
+    Bitwise operators are enabled for this enum by overloading K8090Traits::enableBitmaskOperators(RelayID) function
+    (see enum_flags.h for more details) and so the value of K8090Traits::RelayID type can be also a combination of
+    particular relays.
+*/
+/*!
+    \var RelayID::NONE
+    \brief None relay.
+*/
+/*!
+    \var RelayID::ONE
+    \brief First relay.
+*/
+/*!
+    \var RelayID::TWO
+    \brief Second relay.
+*/
+/*!
+    \var RelayID::THREE
+    \brief Third relay.
+*/
+/*!
+    \var RelayID::FOUR
+    \brief Fourth relay.
+*/
+/*!
+    \var RelayID::FIVE
+    \brief Fifth relay.
+*/
+/*!
+    \var RelayID::SIX
+    \brief Sixth relay.
+*/
+/*!
+    \var RelayID::SEVEN
+    \brief Seventh relay.
+*/
+/*!
+    \var RelayID::EIGHT
+    \brief Eigth relay.
+*/
+/*!
+    \var RelayID::ALL
+    \brief All relays.
+*/
+
+/*!
+    \fn constexpr bool enableBitmaskOperators(RelayID)
+    \brief Function overload which enables bitwise operators for RelayID enumeration. See enum_flags.h for more
+    details.
+
+    \return True to enable bitmask operators.
+*/
+
+/*!
+    \fn constexpr std::underlying_type<E> as_number(const E e)
+    \brief Converts enumeration to its underlying type.
+
+    \param e Enumerator to be converted.
+    \return The enum value as underlying type.
+*/
 
 // static constants
 const quint16 K8090::kProductID = 32912;
 const quint16 K8090::kVendorID = 4303;
 
+/*!
+    \brief Start delimiting byte.
+*/
 const unsigned char kStxByte_ = 0x04;
 /*!
     \brief End delimiting byte.
@@ -58,72 +192,72 @@ constexpr unsigned char getXDataValue();
 
 // specializations
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::RELAY_ON)>()
+constexpr unsigned char getXDataValue<as_number(Command::RELAY_ON)>()
 {
     return 0x11;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::RELAY_OFF)>()
+constexpr unsigned char getXDataValue<as_number(Command::RELAY_OFF)>()
 {
     return 0x12;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::TOGGLE_RELAY)>()
+constexpr unsigned char getXDataValue<as_number(Command::TOGGLE_RELAY)>()
 {
     return 0x14;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::QUERY_RELAY)>()
+constexpr unsigned char getXDataValue<as_number(Command::QUERY_RELAY)>()
 {
     return 0x18;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::SET_BUTTON_MODE)>()
+constexpr unsigned char getXDataValue<as_number(Command::SET_BUTTON_MODE)>()
 {
     return 0x21;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::BUTTON_MODE)>()
+constexpr unsigned char getXDataValue<as_number(Command::BUTTON_MODE)>()
 {
     return 0x22;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::START_TIMER)>()
+constexpr unsigned char getXDataValue<as_number(Command::START_TIMER)>()
 {
     return 0x41;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::SET_TIMER)>()
+constexpr unsigned char getXDataValue<as_number(Command::SET_TIMER)>()
 {
     return 0x42;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::TIMER)>()
+constexpr unsigned char getXDataValue<as_number(Command::TIMER)>()
 {
     return 0x44;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::BUTTON_STATUS)>()
+constexpr unsigned char getXDataValue<as_number(Command::BUTTON_STATUS)>()
 {
     return 0x50;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::RELAY_STATUS)>()
+constexpr unsigned char getXDataValue<as_number(Command::RELAY_STATUS)>()
 {
     return 0x51;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::RESET_FACTORY_DEFAULTS)>()
+constexpr unsigned char getXDataValue<as_number(Command::RESET_FACTORY_DEFAULTS)>()
 {
     return 0x66;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::JUMPER_STATUS)>()
+constexpr unsigned char getXDataValue<as_number(Command::JUMPER_STATUS)>()
 {
     return 0x70;
 }
 template<>
-constexpr unsigned char getXDataValue<static_cast<unsigned int>(K8090Traits::Command::FIRMWARE_VERSION)>()
+constexpr unsigned char getXDataValue<as_number(Command::FIRMWARE_VERSION)>()
 {
     return 0x71;
 }
@@ -164,6 +298,7 @@ const unsigned char XArrayData<Args...>::kValues[sizeof...(Args)] = {Args...};
 
 }  // unnamed namespace
 
+
 /*!
     \class K8090
     \brief The class that provides the interface for Velleman %K8090 relay card
@@ -186,14 +321,14 @@ const unsigned char XArrayData<Args...>::kValues[sizeof...(Args)] = {Args...};
 
     // copying the first two bytes of command to command byte array
     cmd[0] = kStxByte_
-    cmd[1] = commands_[static_cast<int>(Command::RELAY_STATUS)];
-    cmd[2] = static_cast<unsigned char>(RelayID::ONE);  // 3rd byte specifies affected relays
+    cmd[1] = commands_[as_number(Command::RELAY_STATUS)];
+    cmd[2] = as_number(RelayID::ONE);  // 3rd byte specifies affected relays
     // commands, there is no one.
     cmd[5] = K8090::checkSum(cmd, 5); // sixth byte contains check sum.
     cmd[6] = kEtxByte_;
     \endcode
 */
-const unsigned char *K8090::commands_ = XArray<static_cast<unsigned int>(K8090Traits::Command::NONE)>::XData::kValues;
+const unsigned char *K8090::commands_ = XArray<as_number(Command::NONE)>::XData::kValues;
 
 
 /*!
@@ -227,8 +362,6 @@ QList<ComPortParams> K8090::availablePorts()
 
 void K8090::connectK8090()
 {
-    const unsigned char *commands = XArray<static_cast<unsigned int>(K8090Traits::Command::NONE)>::XData::kValues;
-    qDebug() << byteToHex(commands, static_cast<unsigned int>(K8090Traits::Command::NONE));
     bool cardFound = false;
     foreach (const QSerialPortInfo &info, QSerialPortInfo::availablePorts()) {  // NOLINT(whitespace/parens)
         if (info.productIdentifier() == kProductID &&
@@ -300,7 +433,7 @@ void K8090::sendSwitchRelayOnCommand()
     int n = 7;  // Number of command bytes.
     unsigned char * cmd = new unsigned char[n];
     cmd[0] = kStxByte_;
-    cmd[1] = commands_[static_cast<int>(Command::RELAY_ON)];
+    cmd[1] = commands_[as_number(Command::RELAY_ON)];
     cmd[2] = (unsigned char) RelayID::ONE;
     cmd[5] = checkSum(cmd, 5);
     cmd[6] = kEtxByte_;
@@ -318,7 +451,7 @@ void K8090::sendSwitchRelayOffCommand()
     int n = 7;  // Number of command bytes.
     unsigned char * cmd = new unsigned char[n];
     cmd[0] = kStxByte_;
-    cmd[1] = commands_[static_cast<int>(Command::RELAY_OFF)];
+    cmd[1] = commands_[as_number(Command::RELAY_OFF)];
     cmd[2] = (unsigned char) RelayID::ONE;
     cmd[5] = checkSum(cmd, 5);
     cmd[6] = kEtxByte_;
@@ -448,7 +581,7 @@ bool K8090::validateResponse(const unsigned char *bMsg, int n, Command cmd)
     if (n >= 6) {
         if (bMsg[0] != kStxByte_)
             return false;
-        if (bMsg[1] != commands_[static_cast<int>(cmd)])
+        if (bMsg[1] != commands_[as_number(cmd)])
             return false;
         unsigned char bTest[5];
         for (int ii = 0; ii < 5; ++ii)

--- a/src/sprelay/core/k8090.cpp
+++ b/src/sprelay/core/k8090.cpp
@@ -42,22 +42,25 @@ using namespace K8090Traits;  // NOLINT(build/namespaces)
 const quint16 K8090::kProductID = 32912;
 const quint16 K8090::kVendorID = 4303;
 
-const QString K8090::kStxByte_ = "04";
-const QString K8090::kEtxByte_ = "0F";
-const QString K8090::kSwitchRelayOnCmd_ = "11";
-const QString K8090::kSwitchRelayOffCmd_ = "12";
-const QString K8090::kToggleRelayCmd_ = "14";
-const QString K8090::kQueryRelayStatusCmd_ = "18";
-const QString K8090::kSetButtonModeCmd_ = "21";
-const QString K8090::kQueryButtonModeCmd_ = "22";
-const QString K8090::kStartRelayTimerCmd_ = "41";
-const QString K8090::kSetRelayTimerDelayCmd_ = "42";
-const QString K8090::kQueryTimerDelayCmd_ = "44";
-const QString K8090::kButtonStatusCmd_ = "50";
-const QString K8090::kRelayStatusCmd_ = "51";
-const QString K8090::kResetFactoryDefaultsCmd_ = "66";
-const QString K8090::kJumperStatusCmd_ = "70";
-const QString K8090::kFirmwareVersionCmd_ = "71";
+const unsigned char K8090::kStxByte_ = 0x04;
+/*!
+    \brief End delimiting byte.
+*/
+const unsigned char K8090::kEtxByte_ = 0x0f;
+const unsigned char K8090::kSwitchRelayOnCmd_ = 0x11;
+const unsigned char K8090::kSwitchRelayOffCmd_ = 0x12;
+const unsigned char K8090::kToggleRelayCmd_ = 0x14;
+const unsigned char K8090::kQueryRelayStatusCmd_ = 0x18;
+const unsigned char K8090::kSetButtonModeCmd_ = 0x21;
+const unsigned char K8090::kQueryButtonModeCmd_ = 0x22;
+const unsigned char K8090::kStartRelayTimerCmd_ = 0x41;
+const unsigned char K8090::kSetRelayTimerDelayCmd_ = 0x42;
+const unsigned char K8090::kQueryTimerDelayCmd_ = 0x44;
+const unsigned char K8090::kButtonStatusCmd_ = 0x50;
+const unsigned char K8090::kRelayStatusCmd_ = 0x51;
+const unsigned char K8090::kResetFactoryDefaultsCmd_ = 0x66;
+const unsigned char K8090::kJumperStatusCmd_ = 0x70;
+const unsigned char K8090::kFirmwareVersionCmd_ = 0x71;
 
 /*!
     \class K8090
@@ -69,8 +72,7 @@ const QString K8090::kFirmwareVersionCmd_ = "71";
 
 // initialization of static member variables
 /*!
-    \brief Array of 2 byte (1 leading byte and one command byte) commands used
-    to control the relay.
+    \brief Array of hexadecimal representation of commands used to control the relay.
 
     It is filled by fillCommandsArrays() static method, the first command is
     the command with the most important priority, the last is the least
@@ -84,41 +86,15 @@ const QString K8090::kFirmwareVersionCmd_ = "71";
     unsigned char cmd[n]; // array of command bytes
 
     // copying the first two bytes of command to command byte array
-    for (int ii = 0; ii < 2; ++ii)
-        cmd[ii] = b_commands_[static_cast<int>(Command::RELAY_STATUS)][ii];
+    cmd[0] = kStxByte_
+    cmd[1] = commands_[static_cast<int>(Command::RELAY_STATUS)];
     cmd[2] = static_cast<unsigned char>(RelayID::ONE);  // 3rd byte specifies affected relays
     // commands, there is no one.
     cmd[5] = K8090::checkSum(cmd, 5); // sixth byte contains check sum.
-    cmd[6] = b_etx_byte_;
+    cmd[6] = kEtxByte_;
     \endcode
 */
-unsigned char K8090::b_commands_[static_cast<int>(Command::NONE)][2];
-
-/*!
-    \brief End delimiting byte.
-*/
-unsigned char K8090::b_etx_byte_;
-
-/*!
-    \brief Array of QString representation of command bytes used to control
-    the relay card.
-
-    To assemble the full command, it is necessary to prepend the kStxByte
-    and append byte, which specifies the relays to be used, folowed by bytes
-    containing data and ended with checksum (See CheckSum(const unsigned char,
-    int)) and kEtxByte. It is filled by fillCommandsArrays() static method.
-    They should be accessed using the K8090Traits::Command enum values.
-    Example, which shows how to build the whole command _query relay status_:
-    \code
-    QString strCmd(kStxByte);
-    int n = 0; // number of data bytes
-    strCmd.append(strCommands[static_cast<int>(Command::RELAY_STATUS)])
-          .append(" 00 00 00 ")
-          .append(checkSum(strCmd))
-          .append(QString(" %1".arg(kEtxByte_)));
-    \endcode
-*/
-QString K8090::str_commands_[static_cast<int>(Command::NONE)];
+unsigned char K8090::commands_[static_cast<int>(Command::NONE)];
 
 
 /*!
@@ -223,12 +199,11 @@ void K8090::sendSwitchRelayOnCommand()
 {
     int n = 7;  // Number of command bytes.
     unsigned char * cmd = new unsigned char[n];
-    int ii;
-    for (ii = 0; ii < 2; ++ii)
-        cmd[ii] = b_commands_[static_cast<int>(Command::RELAY_ON)][ii];
+    cmd[0] = kStxByte_;
+    cmd[1] = commands_[static_cast<int>(Command::RELAY_ON)];
     cmd[2] = (unsigned char) RelayID::ONE;
     cmd[5] = checkSum(cmd, 5);
-    cmd[6] = b_etx_byte_;
+    cmd[6] = kEtxByte_;
     last_command_ = Command::RELAY_ON;
     qDebug() << byteToHex(cmd, n);
     onSendToSerial(cmd, n);
@@ -242,12 +217,11 @@ void K8090::sendSwitchRelayOffCommand()
 {
     int n = 7;  // Number of command bytes.
     unsigned char * cmd = new unsigned char[n];
-    int ii;
-    for (ii = 0; ii < 2; ++ii)
-        cmd[ii] = b_commands_[static_cast<int>(Command::RELAY_OFF)][ii];
+    cmd[0] = kStxByte_;
+    cmd[1] = commands_[static_cast<int>(Command::RELAY_OFF)];
     cmd[2] = (unsigned char) RelayID::ONE;
     cmd[5] = checkSum(cmd, 5);
-    cmd[6] = b_etx_byte_;
+    cmd[6] = kEtxByte_;
     last_command_ = Command::RELAY_OFF;
     qDebug() << byteToHex(cmd, n);
     onSendToSerial(cmd, n);
@@ -372,9 +346,10 @@ bool K8090::validateResponse(const QString &msg, Command cmd)
 bool K8090::validateResponse(const unsigned char *bMsg, int n, Command cmd)
 {
     if (n >= 6) {
-        for (int ii = 0; ii < 2; ++ii)
-            if (bMsg[ii] != b_commands_[static_cast<int>(cmd)][ii])
-                return false;
+        if (bMsg[0] != kStxByte_)
+            return false;
+        if (bMsg[1] != commands_[static_cast<int>(cmd)])
+            return false;
         unsigned char bTest[5];
         for (int ii = 0; ii < 5; ++ii)
             bTest[ii] = bMsg[ii];
@@ -391,28 +366,20 @@ bool K8090::validateResponse(const unsigned char *bMsg, int n, Command cmd)
  */
 void K8090::fillCommandsArrays()
 {
-    str_commands_[static_cast<int>(Command::RELAY_ON)] = kSwitchRelayOnCmd_;
-    str_commands_[static_cast<int>(Command::RELAY_OFF)] = kSwitchRelayOffCmd_;
-    str_commands_[static_cast<int>(Command::TOGGLE_RELAY)] = kToggleRelayCmd_;
-    str_commands_[static_cast<int>(Command::RELAY_STATUS)] = kQueryRelayStatusCmd_;
-    str_commands_[static_cast<int>(Command::SET_BUTTON_MODE)] = kSetButtonModeCmd_;
-    str_commands_[static_cast<int>(Command::BUTTON_MODE)] = kQueryButtonModeCmd_;
-    str_commands_[static_cast<int>(Command::START_TIMER)] = kStartRelayTimerCmd_;
-    str_commands_[static_cast<int>(Command::SET_TIMER)] = kSetRelayTimerDelayCmd_;
-    str_commands_[static_cast<int>(Command::TIMER)] = kQueryTimerDelayCmd_;
-    str_commands_[static_cast<int>(Command::BUTTON_STATUS)] = kButtonStatusCmd_;
-    str_commands_[static_cast<int>(Command::RELAY_STATUS)] = kRelayStatusCmd_;
-    str_commands_[static_cast<int>(Command::RESET_FACTORY_DEFAULTS)] = kResetFactoryDefaultsCmd_;
-    str_commands_[static_cast<int>(Command::JUMPER_STATUS)] = kJumperStatusCmd_;
-    str_commands_[static_cast<int>(Command::FIRMWARE_VERSION)] = kFirmwareVersionCmd_;
-
-    bool ok;
-    for (int ii = 0; ii < static_cast<int>(Command::NONE); ++ii) {
-        b_commands_[ii][0] = kStxByte_.toUInt(&ok, 16);
-        b_commands_[ii][1] = static_cast<unsigned char>(str_commands_[ii].toUInt(&ok, 16));
-    }
-
-    b_etx_byte_ = kEtxByte_.toUInt(&ok, 16);
+    commands_[static_cast<int>(Command::RELAY_ON)] = kSwitchRelayOnCmd_;
+    commands_[static_cast<int>(Command::RELAY_OFF)] = kSwitchRelayOffCmd_;
+    commands_[static_cast<int>(Command::TOGGLE_RELAY)] = kToggleRelayCmd_;
+    commands_[static_cast<int>(Command::RELAY_STATUS)] = kQueryRelayStatusCmd_;
+    commands_[static_cast<int>(Command::SET_BUTTON_MODE)] = kSetButtonModeCmd_;
+    commands_[static_cast<int>(Command::BUTTON_MODE)] = kQueryButtonModeCmd_;
+    commands_[static_cast<int>(Command::START_TIMER)] = kStartRelayTimerCmd_;
+    commands_[static_cast<int>(Command::SET_TIMER)] = kSetRelayTimerDelayCmd_;
+    commands_[static_cast<int>(Command::TIMER)] = kQueryTimerDelayCmd_;
+    commands_[static_cast<int>(Command::BUTTON_STATUS)] = kButtonStatusCmd_;
+    commands_[static_cast<int>(Command::RELAY_STATUS)] = kRelayStatusCmd_;
+    commands_[static_cast<int>(Command::RESET_FACTORY_DEFAULTS)] = kResetFactoryDefaultsCmd_;
+    commands_[static_cast<int>(Command::JUMPER_STATUS)] = kJumperStatusCmd_;
+    commands_[static_cast<int>(Command::FIRMWARE_VERSION)] = kFirmwareVersionCmd_;
 }
 
 

--- a/src/sprelay/core/k8090.cpp
+++ b/src/sprelay/core/k8090.cpp
@@ -108,7 +108,7 @@ using namespace K8090Traits;  // NOLINT(build/namespaces)
     \enum RelayID
     \brief Scoped enumeration listing all 8 relays.
 
-    Bitwise operators are enabled for this enum by overloading K8090Traits::enableBitmaskOperators(RelayID) function
+    Bitwise operators are enabled for this enum by overloading K8090Traits::enable_bitmask_operators(RelayID) function
     (see enum_flags.h for more details) and so the value of K8090Traits::RelayID type can be also a combination of
     particular relays.
 */
@@ -154,7 +154,7 @@ using namespace K8090Traits;  // NOLINT(build/namespaces)
 */
 
 /*!
-    \fn constexpr bool enableBitmaskOperators(RelayID)
+    \fn constexpr bool enable_bitmask_operators(RelayID)
     \brief Function overload which enables bitwise operators for RelayID enumeration. See enum_flags.h for more
     details.
 

--- a/src/sprelay/core/k8090.h
+++ b/src/sprelay/core/k8090.h
@@ -25,6 +25,8 @@
 
 #include <QObject>
 
+#include <type_traits>
+
 #include "enum_flags.h"
 
 // forward declarations
@@ -33,7 +35,8 @@ class QSerialPort;
 
 namespace K8090Traits
 {
-enum class Command {
+enum class Command : unsigned int
+{
     RELAY_ON,
     RELAY_OFF,
     TOGGLE_RELAY,
@@ -51,13 +54,10 @@ enum class Command {
     NONE
 };
 
-inline Command& operator++(Command &cmd) { cmd = static_cast<Command>(static_cast<int>(cmd) + 1); return cmd; }
-inline Command operator++(Command &cmd, int) { Command tmp(cmd); cmd++; return tmp; }
-
 
 enum struct RelayID : unsigned char
 {
-    NONE  = 0,
+    NONE  = 0,  /**< None relay */
     ONE   = 1 << 0,
     TWO   = 1 << 1,
     THREE = 1 << 2,
@@ -72,6 +72,14 @@ enum struct RelayID : unsigned char
 
 // this redefinition enables bitwise operator usage
 constexpr bool enableBitmaskOperators(RelayID) { return true; }
+
+
+// conversion of scoped enum to underlying_type
+template<typename E>
+constexpr typename std::enable_if<std::is_enum<E>::value, std::underlying_type<E>>::type::type as_number(const E e)
+{
+    return static_cast<typename std::underlying_type<E>::type>(e);
+}
 
 
 struct ComPortParams
@@ -130,7 +138,7 @@ private:  // NOLINT(whitespace/indent)
     QString com_port_name_;
     QSerialPort *serial_port_;
 
-    bool commandBuffer_[static_cast<int>(K8090Traits::Command::NONE)];
+    bool commandBuffer_[K8090Traits::as_number(K8090Traits::Command::NONE)];
 
     K8090Traits::Command last_command_;
 

--- a/src/sprelay/core/k8090.h
+++ b/src/sprelay/core/k8090.h
@@ -71,7 +71,7 @@ enum struct RelayID : unsigned char
 
 
 // this redefinition enables bitwise operator usage
-constexpr bool enableBitmaskOperators(RelayID) { return true; }
+constexpr bool enable_bitmask_operators(RelayID) { return true; }
 
 
 // conversion of scoped enum to underlying_type

--- a/src/sprelay/core/k8090.h
+++ b/src/sprelay/core/k8090.h
@@ -135,26 +135,24 @@ private:  // NOLINT(whitespace/indent)
 
     K8090Traits::Command last_command_;
 
-    static unsigned char b_commands_[static_cast<int>(K8090Traits::Command::NONE)][2];
-    static unsigned char b_etx_byte_;
-    static QString str_commands_[static_cast<int>(K8090Traits::Command::NONE)];
+    static unsigned char commands_[static_cast<int>(K8090Traits::Command::NONE)];
 
-    static const QString kStxByte_;
-    static const QString kEtxByte_;
-    static const QString kSwitchRelayOnCmd_;
-    static const QString kSwitchRelayOffCmd_;
-    static const QString kToggleRelayCmd_;
-    static const QString kQueryRelayStatusCmd_;
-    static const QString kSetButtonModeCmd_;
-    static const QString kQueryButtonModeCmd_;
-    static const QString kStartRelayTimerCmd_;
-    static const QString kSetRelayTimerDelayCmd_;
-    static const QString kQueryTimerDelayCmd_;
-    static const QString kButtonStatusCmd_;
-    static const QString kRelayStatusCmd_;
-    static const QString kResetFactoryDefaultsCmd_;
-    static const QString kJumperStatusCmd_;
-    static const QString kFirmwareVersionCmd_;
+    static const unsigned char kStxByte_;
+    static const unsigned char kEtxByte_;
+    static const unsigned char kSwitchRelayOnCmd_;
+    static const unsigned char kSwitchRelayOffCmd_;
+    static const unsigned char kToggleRelayCmd_;
+    static const unsigned char kQueryRelayStatusCmd_;
+    static const unsigned char kSetButtonModeCmd_;
+    static const unsigned char kQueryButtonModeCmd_;
+    static const unsigned char kStartRelayTimerCmd_;
+    static const unsigned char kSetRelayTimerDelayCmd_;
+    static const unsigned char kQueryTimerDelayCmd_;
+    static const unsigned char kButtonStatusCmd_;
+    static const unsigned char kRelayStatusCmd_;
+    static const unsigned char kResetFactoryDefaultsCmd_;
+    static const unsigned char kJumperStatusCmd_;
+    static const unsigned char kFirmwareVersionCmd_;
 };
 
 #endif  // SPRELAY_CORE_K8090_H_

--- a/src/sprelay/core/k8090.h
+++ b/src/sprelay/core/k8090.h
@@ -121,7 +121,6 @@ private:  // NOLINT(whitespace/indent)
     static unsigned char checkSum(const unsigned char *bMsg, int n);
     static bool validateResponse(const QString &msg, K8090Traits::Command cmd);
     static bool validateResponse(const unsigned char *bMsg, int n, K8090Traits::Command cmd);
-    static void fillCommandsArrays();
 
     void sendCommand();
 
@@ -135,24 +134,7 @@ private:  // NOLINT(whitespace/indent)
 
     K8090Traits::Command last_command_;
 
-    static unsigned char commands_[static_cast<int>(K8090Traits::Command::NONE)];
-
-    static const unsigned char kStxByte_;
-    static const unsigned char kEtxByte_;
-    static const unsigned char kSwitchRelayOnCmd_;
-    static const unsigned char kSwitchRelayOffCmd_;
-    static const unsigned char kToggleRelayCmd_;
-    static const unsigned char kQueryRelayStatusCmd_;
-    static const unsigned char kSetButtonModeCmd_;
-    static const unsigned char kQueryButtonModeCmd_;
-    static const unsigned char kStartRelayTimerCmd_;
-    static const unsigned char kSetRelayTimerDelayCmd_;
-    static const unsigned char kQueryTimerDelayCmd_;
-    static const unsigned char kButtonStatusCmd_;
-    static const unsigned char kRelayStatusCmd_;
-    static const unsigned char kResetFactoryDefaultsCmd_;
-    static const unsigned char kJumperStatusCmd_;
-    static const unsigned char kFirmwareVersionCmd_;
+    static const unsigned char* commands_;
 };
 
 #endif  // SPRELAY_CORE_K8090_H_


### PR DESCRIPTION
Resolves Issue #16. The string constants were replaced by binary representation. Moreover, the command enumerations handling was improved.